### PR TITLE
Fixed problem with ValueError in score

### DIFF
--- a/hnapi.py
+++ b/hnapi.py
@@ -124,7 +124,10 @@ class HackerNewsAPI:
 		"""
 		scoreStart = source.find('>', source.find('>')+1) + 1
 		scoreEnd = source.find(' ', scoreStart)
-		return int(source[scoreStart:scoreEnd])
+		try:
+			return int(source[scoreStart:scoreEnd])
+		except ValueError:
+			return -1
 		
 	def getSubmitter(self, source):
 		"""


### PR DESCRIPTION
Some stories, especially YCombinator's job offers, do not have scores
and the library would raise an exception in these cases. Simple fix.
